### PR TITLE
Correctly normalize css for server side rendering

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,38 @@
 
 module.exports = function(grunt){
 	grunt.initConfig({
+		copy: {
+			toTest: {
+				files: [{
+					expand: true,
+					src:["node_modules/can/**"],
+					dest: "test/tests/ssr",
+					filter: "isFile"
+				}, {
+					expand: true,
+					src:["node_modules/jquery/**"],
+					dest: "test/tests/ssr",
+					filter: "isFile"
+
+				}, {
+					expand: true,
+					src:["node_modules/done-autorender/**"],
+					dest: "test/tests/ssr",
+					filter: "isFile"
+				},{
+					expand: true,
+					src:["node_modules/can-ssr/**"],
+					dest: "test/tests/ssr",
+					filter: "isFile"
+				},{
+					expand: true,
+					src:["node_modules/done-css/**"],
+					dest: "test/tests/ssr",
+					filter: "isFile"
+				}]
+			}
+
+		},
 		testee: {
 		  tests: {
 			options: {
@@ -12,6 +44,7 @@ module.exports = function(grunt){
 	});
 
 	grunt.loadNpmTasks("testee");
+	grunt.loadNpmTasks("grunt-contrib-copy");
 
 	grunt.registerTask("test", ["testee"]);
 };

--- a/component.js
+++ b/component.js
@@ -231,8 +231,8 @@ define(["@loader", "can/view/stache/mustache_core", "can/view/parser/parser"], f
 		if(froms.style) {
 			deps.push(froms.style);
 		} else if(texts.style) {
-			var styleName = name("style", types.style || "css");
-			deps.push(styleName);
+			var styleName = name("style", types.style || "css") + "!";
+			//deps.push(styleName);
 
 			var styleText = texts.style;
 			if(types.style === "less") {
@@ -240,8 +240,9 @@ define(["@loader", "can/view/stache/mustache_core", "can/view/parser/parser"], f
 			}
 
 			var styleLoad = {};
-			var normalizePromise = localLoader.normalize(styleName + "!", load.name);
+			var normalizePromise = localLoader.normalize(styleName, load.name);
 			var locatePromise = normalizePromise.then(function(name){
+				styleName = name;
 				styleLoad = { name: name, metadata: {} };
 				return localLoader.locate(styleLoad);
 			});
@@ -252,6 +253,7 @@ define(["@loader", "can/view/stache/mustache_core", "can/view/parser/parser"], f
 					metadata: styleLoad.metadata,
 					address: address("style", types.style)
 				});
+				deps.push(styleName);
 			});
 		}
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A StealJS plugin for creating <can-component>s",
   "main": "component.js",
   "scripts": {
-    "test": "node_modules/.bin/grunt test"
+    "test:browser": "grunt test",
+    "test:ssr": "grunt copy && mocha test/test_ssr.js",
+    "test": "npm run test:browser && npm run test:ssr"
   },
   "repository": {
     "type": "git",
@@ -22,8 +24,13 @@
   },
   "homepage": "https://github.com/donejs/done-component",
   "devDependencies": {
+    "can-ssr": "^0.5.5",
+    "done-autorender": "^0.3.1",
+    "done-css": "^1.1.6",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
+    "grunt-contrib-copy": "^0.8.1",
+    "mocha": "^2.3.0",
     "steal": "^0.10.5",
     "steal-qunit": "0.0.4",
     "testee": "^0.2.0"
@@ -31,7 +38,11 @@
   "system": {
     "ext": {
       "component": "done-component"
-    }
+    },
+    "npmDependencies": [
+      "steal-qunit",
+      "can"
+    ]
   },
   "dependencies": {
     "can": "^2.3.0-pre.1",

--- a/test/test_ssr.js
+++ b/test/test_ssr.js
@@ -1,0 +1,29 @@
+var canSsr = require("can-ssr");
+var helpers = require("can-ssr/test/helpers");
+var assert = require("assert");
+var path = require("path");
+
+describe("done-component server side rendering", function(){
+	before(function(){
+		this.render = canSsr({
+			config: path.join(__dirname, "tests", "ssr", "package.json!npm"),
+			main: "index.stache!done-autorender"
+		});
+	});
+
+	it("css gets rendered", function(done){
+		this.render("/").then(function(html){
+			var node = helpers.dom(html);
+
+			var foundStyle = false;
+			helpers.traverse(node, function(el){
+				if(el.nodeName === "STYLE") {
+					foundStyle = true;
+				}
+			});
+
+			assert.equal(foundStyle, true, "Found the style element");
+		}).then(done);
+	});
+
+});

--- a/test/tests/ssr/appstate.js
+++ b/test/tests/ssr/appstate.js
@@ -1,0 +1,3 @@
+var AppMap = require("can-ssr/app-map");
+
+module.exports = AppMap.extend({});

--- a/test/tests/ssr/dev.html
+++ b/test/tests/ssr/dev.html
@@ -1,0 +1,1 @@
+<script src="../../../node_modules/steal/steal.js" config="package.json!npm" main="index.stache!done-autorender"></script>

--- a/test/tests/ssr/index.stache
+++ b/test/tests/ssr/index.stache
@@ -1,0 +1,14 @@
+<html>
+	<head>
+		<title>test page</title>
+
+		{{asset "css"}}
+	</head>
+	<body>
+		<can-import from="routes"/>
+		<can-import from="appstate" as="viewModel" />
+		<can-import from="main.component!"/>
+
+		<main-thing></main-thing>
+	</body>
+</html>

--- a/test/tests/ssr/main.component
+++ b/test/tests/ssr/main.component
@@ -1,0 +1,11 @@
+<can-component tag="main-thing">
+	<style>
+		main-thing {
+			background: blue;
+			display: block;
+		}
+	</style>
+	<template>
+		<h1>Hello world</h1>
+	</template>
+</can-component>

--- a/test/tests/ssr/package.json
+++ b/test/tests/ssr/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "basics",
+  "version": "0.0.1",
+  "main": "main.js",
+  "dependencies": {
+    "can": "^2.3.0-pre.1",
+    "done-autorender": "^0.3.1",
+	"can-ssr": "^2.2.0",
+	"done-css": "^1.1.6"
+  },
+  "system": {
+    "paths": {
+      "component": "../../../component.js"
+    }
+  }
+}

--- a/test/tests/ssr/routes.js
+++ b/test/tests/ssr/routes.js
@@ -1,0 +1,4 @@
+var route = require("can/route/route");
+require("can/route/pushstate/pushstate");
+
+route(":page", { page: "home" });


### PR DESCRIPTION
This fixes #1 to make server side rendering work correctly. Previously
there was a bug where, because the css dynamically created didn't
contain the `!` indicator, server-side rendering would not pick up the
style as a css dependency and it would not get created. This fixes it by
making sure it normalizes correctly. Also adds an ssr test.