### PR TITLE
Use reload.disposeModule api for live-reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test:browser": "grunt test",
     "test:ssr": "grunt copy && mocha test/test_ssr.js",
+    "test:live-reload": "live-reload-test & testee test/test-live-reload.html --browsers firefox --reporter Spec",
     "test": "npm run test:browser && npm run test:ssr",
     "publish": "git push origin master --tags",
     "release:patch": "npm version patch && npm publish",
@@ -28,15 +29,17 @@
   },
   "homepage": "https://github.com/donejs/done-component",
   "devDependencies": {
-    "can-ssr": "^0.5.5",
+    "can-ssr": "^0.9.1",
     "done-autorender": "^0.3.1",
-    "done-css": "^1.1.6",
+    "done-css": "^1.1.12",
+    "funcunit": "^3.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-copy": "^0.8.1",
+    "live-reload-testing": "^3.0.1",
     "mocha": "^2.3.0",
-    "steal": "^0.10.5",
-    "steal-qunit": "0.0.4",
+    "steal": "^0.12.0-pre.0",
+    "steal-qunit": "^0.1.0",
     "testee": "^0.2.0"
   },
   "system": {
@@ -45,7 +48,9 @@
     },
     "npmDependencies": [
       "steal-qunit",
-      "can"
+      "can",
+      "live-reload-testing",
+      "funcunit"
     ]
   },
   "dependencies": {

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -1,7 +1,7 @@
 var QUnit = require("steal-qunit");
 var loader = require("@loader");
 
-QUnit.module("can/component/component/system");
+QUnit.module("done-component");
 
 test("Basics works", function(){
 	expect(1);

--- a/test/test-live-reload.html
+++ b/test/test-live-reload.html
@@ -1,0 +1,5 @@
+<title>done-component tests</title>
+<script>
+	FuncUnit = { frameMode: true };
+</script>
+<script src="../node_modules/steal/steal.js" main="test/test-live-reload"></script>

--- a/test/test-live-reload.js
+++ b/test/test-live-reload.js
@@ -1,0 +1,47 @@
+var QUnit = require("steal-qunit");
+var liveReloadTest = require("live-reload-testing");
+var F = require("funcunit");
+
+F.attach(QUnit);
+
+QUnit.module("css", {
+	setup: function(assert){
+		var done = assert.async();
+		F.open("//tests/live/index.html", function(){
+			done();
+		});
+	},
+	teardown: function(assert){
+		var done = assert.async();
+		liveReloadTest.reset().then(function(){
+			done();
+		});
+	}
+});
+
+QUnit.test("removing css works", function(){
+	F("style").exists("the initial style was added to the page");
+
+	F(function(){
+		var address = "test/tests/live/foo.component";
+		var content = '<can-component tag="foo-bar">' +
+			'<style>' +
+			'#app {' +
+			'color: red;' +
+			'height: 20;' +
+			'}' +
+			'</style>' +
+			'<template>' +
+			'Hello world' +
+			'</template>' +
+			'</can-component>';
+
+		liveReloadTest.put(address, content).then(null, function(){
+			QUnit.ok(false, "Changing css was not successful");
+			QUnit.start();
+		});
+	});
+
+   F("#app").exists().height(20, "The height is now correct");
+   F.wait(100);
+});

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,3 @@
-<title>can/component/component/system</title>
+<title>done-component</title>
 <script src="../node_modules/steal/steal.js" main="test/component_test"></script>
 <div id="qunit-fixture"></div>

--- a/test/test_ssr.js
+++ b/test/test_ssr.js
@@ -12,7 +12,9 @@ describe("done-component server side rendering", function(){
 	});
 
 	it("css gets rendered", function(done){
-		this.render("/").then(function(html){
+		this.render("/").then(function(result){
+			var html = result.html;
+
 			var node = helpers.dom(html);
 
 			var foundStyle = false;

--- a/test/tests/live/foo.component
+++ b/test/tests/live/foo.component
@@ -1,0 +1,11 @@
+<can-component tag="foo-bar">
+<style>
+#app {
+color: blue;
+height: 10;
+}
+</style>
+<template>
+Hello world
+</template>
+</can-component>

--- a/test/tests/live/index.html
+++ b/test/tests/live/index.html
@@ -1,0 +1,10 @@
+<script>
+	steal = {
+		configDependencies: ["live-reload"],
+		paths: {
+			"$css": "node_modules/done-css/css.js"
+		}
+	};
+</script>
+<script src="../../../node_modules/steal/steal.js" main="test/tests/live/main"></script>
+<div id="app"></div>

--- a/test/tests/live/main.js
+++ b/test/tests/live/main.js
@@ -1,0 +1,5 @@
+require("./foo.component!");
+var stache = require("can/view/stache/");
+var can = require("can");
+
+can.$("#app").html(stache("<foo-bar></foo-bar>"));


### PR DESCRIPTION
This refactors component.js for better code reuse. Aside from that it
also uses reload.disposeModule which will tear down modules during
live-reload so that their dispose callbacks are called. We need this for
css so that it properly removes the old styles. Closes #4