### PR TITLE
Fix conditions on helpers

### DIFF
--- a/component.js
+++ b/component.js
@@ -265,7 +265,7 @@ define([
 
 		// Define helpers
 		defineVirtualModule({
-			condition: froms.events || texts.events,
+			condition: froms.helpers || texts.helpers,
 			arg: "helpers",
 			name: "helpers",
 			from: froms.helpers,
@@ -274,7 +274,7 @@ define([
 
 		// Define simple-helpers
 		defineVirtualModule({
-			condition: froms.events || texts.events,
+			condition: froms["simple-helpers"] || texts["simple-helpers"],
 			arg: "simpleHelpers",
 			name: "simple-helpers",
 			from: froms["simple-helpers"],

--- a/test/tests/hello-world.component
+++ b/test/tests/hello-world.component
@@ -5,7 +5,7 @@
 		}
 	</style>
 	<template>
-		{{#if visible}}<b>{{message}}</b>{{else}}<i>Click me</i>{{/if}}
+		{{#if visible}}<b>{{caps message}}</b>{{else}}<i>Click me</i>{{/if}}
 	</template>
 	<view-model>
 		export default {
@@ -20,4 +20,10 @@
 			}
 		};
 	</events>
+	<helpers>
+		exports.caps = function(txt){
+			txt = txt.isComputed ? txt() : txt;
+			return txt.toUpperCase();
+		};
+	</helpers>
 </can-component>


### PR DESCRIPTION
Should only define helpers if they are present in the .component
definition.