### PR TITLE
Fix the mocha tests for done-component's ssr

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "can-map-define": "^3.0.0",
     "can-route": "^3.0.6",
     "can-route-pushstate": "^3.0.1",
+    "can-vdom": "^3.2.4",
     "done-autorender": "^1.0.0-alpha.0",
     "done-css": "^3.0.0-alpha.0",
     "done-ssr": "^1.0.0-alpha.2",

--- a/test/test_ssr.js
+++ b/test/test_ssr.js
@@ -2,16 +2,20 @@ var ssr = require("done-ssr");
 var assert = require("assert");
 var path = require("path");
 var through = require("through2");
+var steal = require("steal");
+require("can-vdom");
 
 var helpers = {
 	dom: function(html){
 		html = html.replace("<!DOCTYPE html>", "").trim();
 		var doc = new document.constructor();
 		doc.__addSerializerAndParser(document.__serializer, document.__parser);
-		var div = doc.createElement("div");
-		div.innerHTML = html;
-
-		return div.firstChild;
+		window.LoaderPolyfill = steal.loader.constructor;
+		var div = doc.createElement("html");
+		div.innerHTML = html.trim();
+		// use last child instead of first, because the presence of <!DOCTYPE html>
+		//  will cause the first child to be a text node.
+		return div.lastChild;
 	},
 	traverse: function(node, callback){
 		var cur = node.firstChild;


### PR DESCRIPTION
This PR avoids some issues in can-vdom in setting up the SSR text

- explicitly imports can-vdom to set up the appropriate globals
- sets LoaderPolyfill on the global, since it is used deeply in the lib code
- uses lastChild instead of firstChild when parsing the HTML returned from autorender, because the first child is a text node of the !DOCTYPE tag (will create a separate issue for this)