### PR TITLE
Fix the viewModel -> ViewModel warning

### DIFF
--- a/component.js
+++ b/component.js
@@ -275,10 +275,10 @@ define([
 			source: templateDefine(result, normalize)
 		});
 
-		// Define the viewModel
+		// Define the ViewModel
 		defineVirtualModule({
 			condition: froms["view-model"] || texts["view-model"],
-			arg: "viewModel",
+			arg: "ViewModel",
 			name: "view-model",
 			from: froms["view-model"],
 			source: texts["view-model"]
@@ -355,11 +355,11 @@ define([
 			return "def" + "ine(" + JSON.stringify(deps) + ", function(" +
 				ases.join(", ") + "){\n" +
 				"\tvar __interop = function(m){if(m && m['default']) {return m['default'];}else if(m) return m;};\n\n" +
-				"\tvar viewModel = __interop(typeof viewModel !== 'undefined' ? viewModel : undefined);\n" +
+				"\tvar ViewModel = __interop(typeof ViewModel !== 'undefined' ? ViewModel : undefined);\n" +
 				"\tvar ComponentConstructor = Component.extend({\n" +
 				"\t\ttag: '" + tagName + "',\n" +
 				"\t\tview: __interop(typeof view !== 'undefined' ? view : undefined),\n" +
-				"\t\tviewModel: viewModel,\n" +
+				"\t\tViewModel: ViewModel,\n" +
 				"\t\tevents: __interop(typeof events !== 'undefined' ? events : undefined),\n" +
 				"\t\thelpers: __interop(typeof helpers !== 'undefined' ? helpers : undefined),\n" +
 				"\t\tsimpleHelpers: __interop(typeof simpleHelpers !== 'undefined' ? simpleHelpers : undefined),\n" +
@@ -368,7 +368,6 @@ define([
 				"\treturn {\n" +
 				"\t\tComponent: ComponentConstructor,\n" +
 				"\t\tViewModel: ComponentConstructor.ViewModel,\n" +
-				"\t\tviewModel: viewModel\n" +
 				"\t};\n" +
 				"});";
 		});


### PR DESCRIPTION
This fixes a warning from can-component about assigning a DefineMap to the `viewModel` instead of `ViewModel` (capital V).

Warnings shown when running the tests before this change:
![before](https://user-images.githubusercontent.com/10070176/34425064-9bfeae36-ebdd-11e7-8dbd-57c0e4b2618a.png)


After this change:
![after](https://user-images.githubusercontent.com/10070176/34425066-9f46ac1a-ebdd-11e7-9ed8-2a3a8787c673.png)


Fixes https://github.com/donejs/done-component/issues/58