### PR TITLE
Add improved error messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "jquery": "^3.2.1",
     "live-reload-testing": "^6.0.0",
     "mocha": "^3.2.0",
-    "steal": "^1.0.0",
+    "steal": "^1.7.0",
     "steal-less": "^1.0.2",
     "steal-qunit": "^1.0.0",
     "steal-stache": "^4.0.0",
@@ -65,6 +65,7 @@
   "dependencies": {
     "can-component": "^4.0.0",
     "can-stache": "^4.0.0",
-    "can-view-parser": "^4.0.0"
+    "can-view-parser": "^4.0.0",
+    "steal-config-utils": "^1.0.0"
   }
 }

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -124,3 +124,13 @@ test("leak-scope attribute works", function(){
 
 	stop();
 });
+
+QUnit.test("error messages includes the source", function(){
+	stop();
+	loader.import("~/test/tests/oops.component")
+	.then(null, function(err){
+		ok(/<can-import/.test(err.message), "can-import code is in the message");
+		ok(/oops.component/.test(err.stack), "the importing file is in the stack");
+		start();
+	});
+});

--- a/test/tests/oops.component
+++ b/test/tests/oops.component
@@ -1,0 +1,13 @@
+<can-component tag="oops-component">
+	<view>
+		<can-import from="./file-missing" />
+
+		<section class="app">
+			<div>...</div>
+		</section>
+	</view>
+	<script type="view-model">
+		var DefineMap = require("can-define/map/map");
+		module.exports = DefineMap.extend({});
+	</script>
+</can-component>

--- a/test/tests/ssr/package.json
+++ b/test/tests/ssr/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.1",
   "main": "main.js",
   "dependencies": {
-    "can-component": "^4.0.0-pre.0",
-    "can-define": "^2.0.0-pre.0",
-    "can-route": "^4.0.0-pre.0",
-    "can-route-pushstate": "^4.0.0-pre.0",
-    "done-autorender": "^2.0.0-alpha.0",
-    "steal-stache": "^4.0.0-pre.0",
-	  "done-css": "^3.0.1"
+    "can-component": "^4.0.0",
+    "can-define": "^2.0.0",
+    "can-route": "^4.0.0",
+    "can-route-pushstate": "^4.0.0",
+    "done-autorender": "^2.0.0",
+    "steal-stache": "^4.0.0",
+    "done-css": "^3.0.1",
+    "steal-config-utils": "^1.0.0"
   },
   "system": {
     "ext": {


### PR DESCRIPTION
This uses steal-config-utils/import-specifiers to add the line numbers
that is used for the 404 error message.

Closes #84 

<img width="739" alt="screen shot 2018-03-01 at 9 45 50 am" src="https://user-images.githubusercontent.com/361671/36850675-65e58732-1d35-11e8-88ca-64e18621e906.png">
